### PR TITLE
use sharun hooks and fix strace mode

### DIFF
--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -29,64 +29,18 @@ rm -f *.tar.*
 mv ./chrome-lin ./bin
 ln -s ../bin ./shared/lib
 ln -s ./shared ./usr
-ln -s ./usr/share ./share
 
 # DEPLOY ALL LIBS
 wget --retry-connrefused --tries=30 "$LIB4BIN" -O ./lib4bin
 chmod +x ./lib4bin
-xvfb-run -d -- ./lib4bin -p -v -r -s -e ./bin/chrome*
+./lib4bin -p -v -s ./bin/chrome_*
+xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com
 
-cp -rv /usr/share/glvnd   ./usr/share
-cp -rv /usr/share/vulkan  ./usr/share
-cp -rv /usr/share/X11     ./usr/share
-sed -i 's|/usr/lib/||g'   ./usr/share/vulkan/icd.d/*
-
-# These libs are not found by strace mode for some reason
-# is cromite just not opening in the CI?
-cp -vn /usr/lib/libsoftokn3.so     ./shared/lib
-cp -vn /usr/lib/libhwy.so.1        ./shared/lib
-cp -vn /usr/lib/libheif.so.1       ./shared/lib
-cp -vn /usr/lib/libedit.so*        ./shared/lib
-cp -vn /usr/lib/libelf*.so*        ./shared/lib
-cp -vn /usr/lib/libsensors.so*     ./shared/lib
-cp -vn /usr/lib/libncursesw.so*    ./shared/lib
-cp -vn /usr/lib/libtiff.so*        ./shared/lib
-cp -vn /usr/lib/libcloudproviders* ./shared/lib
-cp -vn /usr/lib/libjbig.so*        ./shared/lib
-cp -vn /usr/lib/libjxl*            ./shared/lib
-cp -vn /usr/lib/libsharpyuv.so*    ./shared/lib
-cp -vn /usr/lib/libjpeg.so*        ./shared/lib
-cp -vn /usr/lib/libva-drm*         ./shared/lib
-cp -vn /usr/lib/libva.so*          ./shared/lib
-cp -vn /usr/lib/libGL*             ./shared/lib
-cp -vn /usr/lib/libnss*            ./shared/lib
-cp -vn /usr/lib/libfreeblpriv3.so  ./shared/lib
-cp -vn /usr/lib/libepoxy.so*       ./shared/lib
-cp -vn /usr/lib/libresolv.so*      ./shared/lib
-cp -vn /usr/lib/libsqlite3.so*     ./shared/lib
-cp -vn /usr/lib/libgtk-*           ./shared/lib
-cp -vn /usr/lib/libgdk*            ./shared/lib
-cp -vn /usr/lib/libcairo-go*       ./shared/lib
-cp -vn /usr/lib/libpango*          ./shared/lib
-cp -vn /usr/lib/libXcursor.so*     ./shared/lib
-cp -vn /usr/lib/libX11-xcb.so*     ./shared/lib
-cp -vn /usr/lib/libXinerama.so*    ./shared/lib
-cp -vn /usr/lib/libxshmfence.so*   ./shared/lib
-cp -vn /usr/lib/libXxf86vm.so*     ./shared/lib
 cp -vn /usr/lib/libwayland*        ./shared/lib
-cp -vn /usr/lib/libx265.so*        ./shared/lib
-cp -vn /usr/lib/libxcb-*           ./shared/lib
-cp -vn /usr/lib/libpci.so*         ./shared/lib
-cp -vn /usr/lib/libpciaccess.so*   ./shared/lib
-cp -vn /usr/lib/libvulkan*         ./shared/lib
-cp -vn /usr/lib/libGLU*            ./shared/lib
-cp -vn /usr/lib/libLLVM.so.18.1    ./shared/lib
-cp -vn /usr/lib/libglapi.so*       ./shared/lib
-cp -vn /usr/lib/libdrm_*           ./shared/lib
-cp -vn /usr/lib/libgallium-*       ./shared/lib
-cp -vr /usr/lib/pkcs11             ./shared/lib
+cp -vn /usr/lib/libnss*            ./shared/lib
 cp -vr /usr/lib/gtk-3.0            ./shared/lib
 cp -vr /usr/lib/gconv              ./shared/lib
+cp -vr /usr/lib/pkcs11             ./shared/lib
 cp -vr /usr/lib/gvfs               ./shared/lib
 cp -vr /usr/lib/gio                ./shared/lib
 cp -vr /usr/lib/dri                ./shared/lib

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -36,7 +36,7 @@ chmod +x ./lib4bin
 ./lib4bin -p -v -s ./bin/chrome_*
 xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com --no-sandbox
 
-find ./bin/__w -type f -exec mv -v {} ./shared/bin \;
+find ./bin/*/*/*/*/* -type f -name '*.so*' -exec mv -v {} ./shared/bin \; || true
 
 cp -vn /usr/lib/libwayland*        ./shared/lib
 cp -vn /usr/lib/libnss*            ./shared/lib

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -38,6 +38,7 @@ xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com
 
 cp -vn /usr/lib/libwayland*        ./shared/lib
 cp -vn /usr/lib/libnss*            ./shared/lib
+cp -vn /usr/lib/libgtk-*           ./shared/lib
 cp -vr /usr/lib/gtk-3.0            ./shared/lib
 cp -vr /usr/lib/gconv              ./shared/lib
 cp -vr /usr/lib/pkcs11             ./shared/lib

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -34,6 +34,7 @@ ln -s ./shared ./usr
 wget --retry-connrefused --tries=30 "$LIB4BIN" -O ./lib4bin
 chmod +x ./lib4bin
 ./lib4bin -p -v -s ./bin/chrome_*
+./bin/chrome google.com
 xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com
 
 cp -vn /usr/lib/libwayland*        ./shared/lib

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -36,9 +36,13 @@ chmod +x ./lib4bin
 ./lib4bin -p -v -s ./bin/chrome_*
 xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com --no-sandbox
 
+find ./bin/__w -type f -exec mv -v {} ./shared/bin \;
+
 cp -vn /usr/lib/libwayland*        ./shared/lib
 cp -vn /usr/lib/libnss*            ./shared/lib
-cp -vn /usr/lib/libgtk-*           ./shared/lib
+cp -vn /usr/lib/libfreeblpriv3.so  ./shared/lib
+cp -vn /usr/lib/libgtk*            ./shared/lib
+cp -vn /usr/lib/libgdk*            ./shared/lib
 cp -vr /usr/lib/gtk-3.0            ./shared/lib
 cp -vr /usr/lib/gconv              ./shared/lib
 cp -vr /usr/lib/pkcs11             ./shared/lib
@@ -49,7 +53,7 @@ cp -vr /usr/lib/dri                ./shared/lib
 ldd ./shared/lib/libsoftokn3.so \
 	./shared/lib/libLLVM* \
 	./shared/lib/libnss* \
-	./shared/lib/libgtk-*
+	./shared/lib/libgtk*
 	./shared/lib/libGL* 2>/dev/null \
 	| awk -F"[> ]" '{print $4}' | xargs -I {} cp -vn {} ./lib
 

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -34,8 +34,7 @@ ln -s ./shared ./usr
 wget --retry-connrefused --tries=30 "$LIB4BIN" -O ./lib4bin
 chmod +x ./lib4bin
 ./lib4bin -p -v -s ./bin/chrome_*
-./bin/chrome google.com
-xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com
+xvfb-run -d -- ./lib4bin -p -v -r -s -e -k ./bin/chrome -- google.com --no-sandbox
 
 cp -vn /usr/lib/libwayland*        ./shared/lib
 cp -vn /usr/lib/libnss*            ./shared/lib

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -42,6 +42,10 @@ cp -vn /usr/lib/libwayland*        ./shared/lib
 cp -vn /usr/lib/libnss*            ./shared/lib
 cp -vn /usr/lib/libfreeblpriv3.so  ./shared/lib
 cp -vn /usr/lib/libgtk*            ./shared/lib
+cp -vn /usr/lib/libcloudproviders* ./shared/lib
+cp -vn /usr/lib/libGLX*            ./shared/lib
+cp -vn /usr/lib/libxcb-glx*        ./shared/lib
+cp -vn /usr/lib/libXinerama*       ./shared/lib
 cp -vn /usr/lib/libgdk*            ./shared/lib
 cp -vr /usr/lib/gtk-3.0            ./shared/lib
 cp -vr /usr/lib/gconv              ./shared/lib
@@ -51,9 +55,10 @@ cp -vr /usr/lib/gio                ./shared/lib
 cp -vr /usr/lib/dri                ./shared/lib
 
 ldd ./shared/lib/libsoftokn3.so \
+	./shared/lib/libwayland* \
 	./shared/lib/libLLVM* \
 	./shared/lib/libnss* \
-	./shared/lib/libgtk*
+	./shared/lib/libgtk* \
 	./shared/lib/libGL* 2>/dev/null \
 	| awk -F"[> ]" '{print $4}' | xargs -I {} cp -vn {} ./lib
 


### PR DESCRIPTION
The reason I had to copy so many libs manually was because chromium was failing in strace mode due to it not allowing sandbox when ran by root, I had to pass the `--no-sandbox` flag to fix this issue. 

I still have to copy some libs manually, but it is much better now. Ever since v131.0.6778.109 mesa was broken while it worked with the previous release, likely something changed in Cromite that new libs are needed and since strace mode wasn't working this was an endless cat and mouse game. 