### PR TITLE
use debloated llvm libs

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -89,7 +89,7 @@ jobs:
             GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           continue-on-error: true
         - name: Continuous Releaser
-          uses: softprops/action-gh-release@v2
+          uses: softprops/action-gh-release@v2.2.1
           with:
             name: "Cromite ${{ env.APP_VERSION}}"
             tag_name: "${{ env.APP_VERSION}}"
@@ -109,7 +109,7 @@ jobs:
             echo SNAPSHOT_TAG="${SNAPSHOT_TAG}" >> "${GITHUB_ENV}"
           continue-on-error: false
         - name: Snapshot Releaser
-          uses: softprops/action-gh-release@v2
+          uses: softprops/action-gh-release@v2.2.1
           with:
             name: "Snapshot ${{ env.APP_VERSION}}"
             tag_name: "${{ env.SNAPSHOT_TAG}}"

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install debloated llvm-libs
       run: |
         LLVM="$(wget https://api.github.com/repos/Samueru-sama/llvm-libs-debloated/releases -O - \
-          | sed 's/[()",{} ]/\n/g' | grep -oi "https.*pkg.tar.zst$" | head -1)"
+          | sed 's/[()",{} ]/\n/g' | grep -oi "https.*very-minimal.pkg.tar.zst$" | head -1)"
         wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
         pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
         

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: build
+    - name: Get dependencies
       if: always()
       run: |
         sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
@@ -31,10 +31,19 @@ jobs:
           libxcb xcb-util-keysyms gvfs libepoxy highway libheif libjxl x265 \
           xcb-util-cursor gtkmm3 glu
 
-        chmod +x ./*-appimage.sh && ./*-appimage.sh
-        mkdir dist
-        mv *.AppImage* dist/
-        mv *.AppBundle* dist/
+    - name: Install debloated llvm-libs
+      run: |
+        LLVM="$(wget https://api.github.com/repos/Samueru-sama/llvm-libs-debloated/releases -O - \
+          | sed 's/[()",{} ]/\n/g' | grep -oi "https.*pkg.tar.zst$" | head -1)"
+        wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
+        pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
+        
+    - name: Make AppImage/AppBundle
+      run: |
+       chmod +x ./*-appimage.sh && ./*-appimage.sh
+       mkdir dist
+       mv *.AppImage* dist/
+       mv *.AppBundle* dist/
 
     - name: Check version file
       run: |

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -29,7 +29,7 @@ jobs:
         printf "\n[extra]\nInclude = /etc/pacman.d/mirrorlist-arch\n" | tee -a /etc/pacman.conf
         pacman -Syu --noconfirm zsync nss chromium gtk3 wayland libva libtiff \
           libxcb xcb-util-keysyms gvfs libepoxy highway libheif libjxl x265 \
-          xcb-util-cursor gtkmm3 glu
+          xcb-util-cursor gtkmm3 glu pulseaudio-alsa
 
     - name: Install debloated llvm-libs
       run: |

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -53,7 +53,8 @@ xvfb-run -a -- ./lib4bin -p -v -s -e -k ./bin/chrome -- google.com --no-sandbox
 	/usr/lib/gvfs/* \
 	/usr/lib/gio/modules/* \
 	/usr/lib/dri/* \
-	/usr/lib/pulseaudio/* 
+	/usr/lib/pulseaudio/* \
+	/usr/lib/alsa-lib/*
 
 rm -f ./bin/chrome ./bin/chrome_sandbox ./bin/chrome_crashpad_handler
 ln ./sharun ./bin/chrome


### PR DESCRIPTION
Results in a 10% reduction in size.

Test carefully, I'm specially interested on errors on the terminal that don't show up in older versions of Cromite.

[Artifacts](https://github.com/Samueru-sama/Cromite-AppImage-test/releases/tag/v132.0.6834.122)