### PR TITLE
use iculess libxml and fix mesa missing gbm error

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -33,9 +33,17 @@ jobs:
 
     - name: Install debloated llvm-libs
       run: |
-        LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
-        wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
+        LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
+        wget --retry-connrefused --tries=30 "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
         pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
+        rm -f ./llvm-libs.pkg.tar.zst
+
+    - name: Install iculess libxml2
+      run: |
+        LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
+        wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
+        pacman -U --noconfirm ./libxml2-iculess.pkg.tar.zst
+        rm -f ./libxml2-iculess.pkg.tar.zst
         
     - name: Make AppImage/AppBundle
       run: |

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -53,6 +53,7 @@ xvfb-run -a -- ./lib4bin -p -v -s -e -k ./bin/chrome -- google.com --no-sandbox
 	/usr/lib/gvfs/* \
 	/usr/lib/gio/modules/* \
 	/usr/lib/dri/* \
+	/usr/lib/gbm/* \
 	/usr/lib/pulseaudio/* \
 	/usr/lib/alsa-lib/*
 
@@ -64,6 +65,19 @@ find ./bin/*/*/*/*/* -type f -name '*.so*' -exec mv -v {} ./bin \; || true
 
 # Weird
 ln -s ../bin/chrome ./shared/bin/exe
+
+# Seems libgbm.so.1 is hardcoded to look into /usr/lib/gbm
+# Is there an env variable that can overwrite this instead? We will use ld-preload-open for now
+git clone https://github.com/fritzw/ld-preload-open.git
+(
+	cd ld-preload-open
+	make all
+	mv ./path-mapping.so ../
+)
+rm -rf ld-preload-open
+mv ./path-mapping.so ./lib
+echo 'path-mapping.so' > ./.preload
+echo 'PATH_MAPPING=/usr/lib/gbm:${SHARUN_DIR}/lib/gbm' >> ./.env
 
 # DESKTOP AND ICON
 cat > "$PACKAGE".desktop << EOF

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -67,17 +67,9 @@ find ./bin/*/*/*/*/* -type f -name '*.so*' -exec mv -v {} ./bin \; || true
 ln -s ../bin/chrome ./shared/bin/exe
 
 # Seems libgbm.so.1 is hardcoded to look into /usr/lib/gbm
-# Is there an env variable that can overwrite this instead? We will use ld-preload-open for now
-git clone https://github.com/fritzw/ld-preload-open.git
-(
-	cd ld-preload-open
-	make all
-	mv ./path-mapping.so ../
-)
-rm -rf ld-preload-open
-mv ./path-mapping.so ./lib
-echo 'path-mapping.so' > ./.preload
-echo 'PATH_MAPPING=/usr/lib/gbm:${SHARUN_DIR}/lib/gbm' >> ./.env
+# Is there an env variable that can overwrite this instead?
+sed -i 's|/usr|././|g' ./lib/libgbm.so*
+echo 'SHARUN_WORKING_DIR=${SHARUN_DIR}' >> ./.env
 
 # DESKTOP AND ICON
 cat > "$PACKAGE".desktop << EOF


### PR DESCRIPTION
Makes the AppImage 10 MiB smaller. 

@xplshn Can I get a quick test? 

---------------------------------------------------------

@VHSgunzo is there a better way to fix the hardcoded /usr/lib/gbm/dri_gbm.so` I checked the env variables of mesa but could not find anything that would help here. 

I tried ld-preload-open and while the library reports having mapped the location when `libgbm.so` tries to load it, it still errors saying that it can't find it.