### PR TITLE
add friendly way to disable ubuntu's namespaces restriction nonsense

### DIFF
--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -90,7 +90,7 @@ CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
 # check if we namespaces restriction from ubuntu before starting cromite
 "$CURRENTDIR"/detect-nonsense.sh
 exec "$CURRENTDIR"/bin/chrome "$@"
-'
+' > ./AppRun
 chmod +x ./AppRun ./detect-nonsense.sh
 
 # MAKE APPIMAGE WITH URUNTIME

--- a/cromite-appimage.sh
+++ b/cromite-appimage.sh
@@ -20,6 +20,7 @@ URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime
 
 # Prepare AppDir
 mkdir -p ./AppDir
+cp -v ./detect-nonsense.sh ./AppDir
 cd ./AppDir
 
 wget --retry-connrefused --tries=30 "$CROMITE_URL"
@@ -82,8 +83,15 @@ ln -s ./"$PACKAGE".png ./.DirIcon
 
 # Prepare sharun
 echo "Preparing sharun..."
-ln -s ./bin/chrome ./AppRun
 ./sharun -g
+
+echo '#!/bin/sh
+CURRENTDIR="$(cd "${0%/*}" && echo "$PWD")"
+# check if we namespaces restriction from ubuntu before starting cromite
+"$CURRENTDIR"/detect-nonsense.sh
+exec "$CURRENTDIR"/bin/chrome "$@"
+'
+chmod +x ./AppRun ./detect-nonsense.sh
 
 # MAKE APPIMAGE WITH URUNTIME
 cd ..

--- a/detect-nonsense.sh
+++ b/detect-nonsense.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+CACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+info_message="
+Starting Ubuntu24.04 canonical decided that namespaces are not safe and is preventing us from using it to sandbox applications.
+
+For more details see: https://github.com/Samueru-sama/fix-ubuntu-nonsense/blob/main/README.md#why
+
+Namespaces are safe and a vital part of the security model of all web browsers, flatpak, electron apps, etc
+
+To fix this issue I will need permission to disable the restriction, like all other linux distros do and several ubuntu forks had to undo.
+"
+
+how_to_undo="
+If you wish to undo this change remove: '/etc/sysctl.d/20-fix-namespaces.conf',
+then run 'sysctl -w kernel.apparmor_restrict_unprivileged_userns=1' or reboot.
+"
+
+warning_text="
+WARNING: I'm not able to create a namespace and not sure what is preventing it.
+
+We will continue without prompting but if something breaks you know why.
+"
+
+do_not_ask_again="Do you wish to not see this message again?"
+
+_display_message() {
+	if command -v zenity 1>/dev/null; then
+		zenity --warning --text "$*"
+	elif command -v kdialog 1>/dev/null; then
+		kdialog --warningcontinuecancel "$*"
+	fi
+}
+
+_false_positive_check(){
+	FALSE_POSITIVE=0
+
+	# Unlikely to be ubuntu or its spins if any of these conditions are true
+	if ! command -v sysctl; then
+		FALSE_POSITIVE=1
+	elif ! command -v zenity && ! command -v kdialog; then
+		FALSE_POSITIVE=1
+	elif ! command -v unshare || ! command -v /bin/true; then
+		FALSE_POSITIVE=1
+	elif [ ! -d /etc/apparmor.d ] || [ ! -d /etc/sysctl.d ]; then
+		FALSE_POSITIVE=1
+	fi
+	if [ "$FALSE_POSITIVE" = 1 ]; then
+		>&2 echo "$warning_text"
+		exit 0
+	fi
+}
+
+_fix_mess() {
+	if _display_message "$info_message"; then
+		pkexec /bin/sh -c "
+			echo 'kernel.apparmor_restrict_unprivileged_userns = 0' \
+			  | tee /etc/sysctl.d/20-fix-namespaces.conf
+			sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+		"
+		if [ -f /etc/sysctl.d/20-fix-namespaces.conf ]; then
+			_display_message "$how_to_undo"
+		fi
+	elif _display_message "$do_not_ask_again"; then
+		echo "delete me to enable again" > "$CACHEDIR"/.disable-namespace-check
+	fi
+}
+
+if unshare --user -p /bin/true >/dev/null 2>&1; then
+	exit 0
+elif [ -f "$CACHEDIR"/.disable-namespace-check ] || [ -f /etc/sysctl.d/20-fix-namespaces.conf ]; then
+	exit 0
+else
+	_false_positive_check 1>/dev/null
+	_fix_mess
+fi


### PR DESCRIPTION
https://github.com/Samueru-sama/fix-ubuntu-nonsense

<img width="1426" height="873" alt="Screenshot_2025-08-06_22-33-07" src="https://github.com/user-attachments/assets/c93ceea5-7e0d-40da-9c81-6ed51175a737" />

<img width="1426" height="873" alt="Screenshot_2025-08-06_22-33-20" src="https://github.com/user-attachments/assets/1fec58f6-e841-42a9-970d-37d90bfab693" />

<img width="1426" height="873" alt="Screenshot_2025-08-06_22-33-35" src="https://github.com/user-attachments/assets/4fc27f50-5446-462f-9288-8519131702cb" />

<img width="1426" height="873" alt="Screenshot_2025-08-06_22-34-02" src="https://github.com/user-attachments/assets/c896c3b2-2295-4737-b222-f52e4f552ee2" />

